### PR TITLE
ProgressDialog Modal option

### DIFF
--- a/widgets/ProgressDialog.cpp
+++ b/widgets/ProgressDialog.cpp
@@ -19,14 +19,21 @@
 #include <QApplication>
 #include <QTimer>
 
-ProgressDialog::ProgressDialog(QString message, bool cancellable,
-                               int timeBeforeShow, QWidget *parent) : 
+ProgressDialog::ProgressDialog(
+    QString message,
+    bool cancellable,
+    int timeBeforeShow,
+    QWidget *parent,
+    Qt::WindowModality modality
+) : 
     m_showTimer(0),
     m_timerElapsed(false),
     m_cancelled(false)
 {
     m_dialog = new QProgressDialog(message, cancellable ? tr("Cancel") : 0,
                                    0, 100, parent);
+    m_dialog->setWindowModality(modality);
+
     if (timeBeforeShow > 0) {
         m_dialog->hide();
         m_showTimer = new QTimer;
@@ -97,9 +104,6 @@ void
 ProgressDialog::setProgress(int percentage)
 {
     if (percentage > m_dialog->value()) {
-
-        m_dialog->setValue(percentage);
-
         if (percentage >= 100 && isDefinite()) {
             m_dialog->hide();
         } else if (m_timerElapsed && !m_dialog->isVisible()) {
@@ -107,8 +111,7 @@ ProgressDialog::setProgress(int percentage)
             m_dialog->show();
             m_dialog->raise();
         }
-
-        qApp->processEvents();
+        m_dialog->setValue(percentage); // processes event loop when modal
+        if (!m_dialog->isModal()) qApp->processEvents();
     }
 }
-

--- a/widgets/ProgressDialog.cpp
+++ b/widgets/ProgressDialog.cpp
@@ -19,13 +19,11 @@
 #include <QApplication>
 #include <QTimer>
 
-ProgressDialog::ProgressDialog(
-    QString message,
-    bool cancellable,
-    int timeBeforeShow,
-    QWidget *parent,
-    Qt::WindowModality modality
-) : 
+ProgressDialog::ProgressDialog(QString message,
+                               bool cancellable,
+                               int timeBeforeShow,
+                               QWidget *parent,
+                               Qt::WindowModality modality) : 
     m_showTimer(0),
     m_timerElapsed(false),
     m_cancelled(false)

--- a/widgets/ProgressDialog.h
+++ b/widgets/ProgressDialog.h
@@ -25,8 +25,13 @@ class ProgressDialog : public ProgressReporter
     Q_OBJECT
     
 public:
-    ProgressDialog(QString message, bool cancellable,
-                   int timeBeforeShow = 0, QWidget *parent = 0);
+    ProgressDialog(
+        QString message,
+        bool cancellable,
+        int timeBeforeShow = 0,
+        QWidget *parent = 0,
+        Qt::WindowModality modality = Qt::NonModal
+    );
     virtual ~ProgressDialog();
 
     virtual bool isDefinite() const;

--- a/widgets/ProgressDialog.h
+++ b/widgets/ProgressDialog.h
@@ -25,13 +25,11 @@ class ProgressDialog : public ProgressReporter
     Q_OBJECT
     
 public:
-    ProgressDialog(
-        QString message,
-        bool cancellable,
-        int timeBeforeShow = 0,
-        QWidget *parent = 0,
-        Qt::WindowModality modality = Qt::NonModal
-    );
+    ProgressDialog(QString message,
+                   bool cancellable,
+                   int timeBeforeShow = 0,
+                   QWidget *parent = 0,
+                   Qt::WindowModality modality = Qt::NonModal);
     virtual ~ProgressDialog();
 
     virtual bool isDefinite() const;


### PR DESCRIPTION
Optionally display as a modal. This small change relates to sonic-visualiser/svcore#3, as exporting the audio data takes some time, the simplest thing to do to avoid changes to the underlying Model is to display a ProgressDialog as a modal.

This class hasn't been touched in almost a decade, so I tried to keep it short. There is probably quite a lot of logic that could be removed as QProgressDialog has likely changed a bit over the years, but I didn't want to get into that.