### PR TITLE
Note delimiters

### DIFF
--- a/layer/NoteDelimiters.cpp
+++ b/layer/NoteDelimiters.cpp
@@ -1,0 +1,51 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Sonic Visualiser
+    An audio file viewer and annotation editor.
+    Centre for Digital Music, Queen Mary, University of London.
+    
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+*/
+
+#include "NoteDelimiters.h"
+
+#include <QPainter>
+
+#include <cmath>
+
+#include "base/Pitch.h"
+
+#include "LayerGeometryProvider.h"
+
+#include <iostream>
+using namespace std;
+
+void NoteDelimiters::paintDelimitersVertical
+    (LayerGeometryProvider *v, QPainter &paint, QRect r,
+    double minf, double maxf)
+{
+    int x0 = r.x(), y0 = r.y(), x1 = r.x() + r.width(), y1 = r.y() + r.height();
+
+    int py = y1;
+    paint.setPen(Qt::gray);
+
+    for (int i = 0; i < 128; ++i) {
+
+        double f = Pitch::getFrequencyForPitch(i);
+        int y = int(lrint(v->getYForFrequency(f, minf, maxf, true)));
+
+        if (y < y0 - 2) break;
+        if (y > y1 + 2) {
+            continue;
+        }
+
+        paint.drawLine(x0, (y + py) / 2, x1, (y + py) / 2);
+
+        py = y;
+    }
+}

--- a/layer/NoteDelimiters.h
+++ b/layer/NoteDelimiters.h
@@ -1,0 +1,30 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Sonic Visualiser
+    An audio file viewer and annotation editor.
+    Centre for Digital Music, Queen Mary, University of London.
+    
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+*/
+
+#ifndef SV_NOTE_DELIMITERS_H
+#define SV_NOTE_DELIMITERS_H
+
+#include <QRect>
+
+class LayerGeometryProvider;
+class QPainter;
+
+class NoteDelimiters {
+public: 
+    void paintDelimitersVertical
+    (LayerGeometryProvider* v, QPainter& paint, QRect rect,
+        double minf, double maxf);
+};
+
+#endif

--- a/layer/SpectrogramLayer.cpp
+++ b/layer/SpectrogramLayer.cpp
@@ -32,6 +32,7 @@
 
 #include "ColourMapper.h"
 #include "PianoScale.h"
+#include "NoteDelimiters.h"
 #include "PaintAssistant.h"
 #include "Colour3DPlotRenderer.h"
 #include "Colour3DPlotExporter.h"
@@ -84,7 +85,8 @@ SpectrogramLayer::SpectrogramLayer(Configuration config) :
     m_synchronous(false),
     m_haveDetailedScale(false),
     m_exiting(false),
-    m_peakCacheDivisor(8)
+    m_peakCacheDivisor(8),
+    m_delimiters(false)
 {
     QString colourConfigName = "spectrogram-colour";
     int colourConfigDefault = int(ColourMapper::Green);
@@ -2208,7 +2210,7 @@ SpectrogramLayer::paintVerticalScale(LayerGeometryProvider *v, bool detailed,
 
     //!!! cache this?
     
-    int h = rect.height(), w = rect.width();
+    int h = rect.height(), w = this->getVerticalScaleWidth(v, detailed, paint);
     int textHeight = paint.fontMetrics().height();
 
     if (detailed && (h > textHeight * 3 + 10)) {
@@ -2276,9 +2278,17 @@ SpectrogramLayer::paintVerticalScale(LayerGeometryProvider *v, bool detailed,
 
         // piano keyboard
 
+        auto m_scaleWidth = this->getVerticalScaleWidth
+            (v, detailed, paint);
         PianoScale().paintPianoVertical
-            (v, paint, QRect(w - pkw - 1, 0, pkw, h),
-             getEffectiveMinFrequency(), getEffectiveMaxFrequency());
+            (v, paint, QRect(m_scaleWidth - pkw - 1, 0, pkw, h),
+                getEffectiveMinFrequency(), getEffectiveMaxFrequency());
+
+        if (m_delimiters) {
+            NoteDelimiters().paintDelimitersVertical
+                (v, paint, QRect(m_scaleWidth, 0, rect.width(), h),
+                    getEffectiveMinFrequency(), getEffectiveMaxFrequency());
+        }
     }
 
     m_haveDetailedScale = detailed;

--- a/layer/SpectrogramLayer.h
+++ b/layer/SpectrogramLayer.h
@@ -292,6 +292,7 @@ protected:
     bool                m_normalizeVisibleArea;
     int                 m_lastEmittedZoomStep;
     bool                m_synchronous;
+    bool                m_delimiters;
 
     mutable bool        m_haveDetailedScale;
 


### PR DESCRIPTION
Dear Sonic Visualizer team,

I think it would be great to have some improvements to the Sonic Visualiser interface. The first of these could be adding separators between notes to make note view more clear like in Melodyne. 

If you approve this PR than the next step is to add a button "show note delimitets" to the view tab. 
Anyway this is just a proposal, so, I open for any feedback.

![delimiters](https://user-images.githubusercontent.com/79649566/228217714-fe4c49d1-fb6b-4f68-b3ff-5c28c7207b46.jpg)

Kind regards,
Alexander